### PR TITLE
Open oofce and jod convertor have conflicting ports

### DIFF
--- a/templates/alfresco-global.properties
+++ b/templates/alfresco-global.properties
@@ -50,14 +50,14 @@ monitor.rmi.service.port=0
 
 ### External executable locations ###
 ooo.exe={{ libre_office_path }}
-ooo.enabled={{ libre_office_enabled|default('true') }}
+ooo.enabled={{ libre_office_enabled|default('false') }}
 ooo.port={{ open_office_port|default(8200) }}
 img.root=/usr/bin
 img.dyn=${img.root}/lib
 img.exe=/usr/bin/convert
 img.gslib=/usr/share/ghostscript/{{ ghostscript_ver }}/lib
 
-jodconverter.enabled=true
+jodconverter.enabled={{ jod_convertor_enabled|default('true') }}
 jodconverter.officeHome={{ libre_office_path | replace('/program/soffice.bin',  '') }}
 jodconverter.portNumbers={{ jod_converter_port|default(8100) }}
 

--- a/templates/alfresco-global.properties
+++ b/templates/alfresco-global.properties
@@ -51,7 +51,7 @@ monitor.rmi.service.port=0
 ### External executable locations ###
 ooo.exe={{ libre_office_path }}
 ooo.enabled={{ libre_office_enabled|default('true') }}
-ooo.port=8100
+ooo.port={{ open_office_port|default(8200) }}
 img.root=/usr/bin
 img.dyn=${img.root}/lib
 img.exe=/usr/bin/convert
@@ -59,7 +59,7 @@ img.gslib=/usr/share/ghostscript/{{ ghostscript_ver }}/lib
 
 jodconverter.enabled=true
 jodconverter.officeHome={{ libre_office_path | replace('/program/soffice.bin',  '') }}
-jodconverter.portNumbers=8100
+jodconverter.portNumbers={{ jod_converter_port|default(8100) }}
 
 ### License location ###
 dir.license.external={{ alfresco_licence|default('/usr/share/tomcat/shared/classes/alfresco/extension/license') }}


### PR DESCRIPTION
Fix for
```2019-03-27 07:40:19,024 ERROR [org.alfresco.util.JodCoordination] Both OOoDirect and OOoJodconverter subsystems are enabled and have specified the same port number on the localhost.
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination]    ooo.enabled=true
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination]    ooo.host=localhost
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination]    ooo.port=8100
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination]    jodconverter.portNumbers=8100
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination]    jodconverter.enabled=true
2019-03-27 07:40:19,025 ERROR [org.alfresco.util.JodCoordination] The OOoDirect subsystem will not start its OpenOffice process as a result.

```
