### PR TITLE
Remove the prepending of the protocol for the messaging broker

### DIFF
--- a/templates/alfresco-global.properties
+++ b/templates/alfresco-global.properties
@@ -196,7 +196,7 @@ messaging.broker.RedeliveryDelay=5000
 messaging.broker.backOffMultiplier=8
 messaging.broker.useExponentialBackOff=true
 messaging.broker.maximumRedeliveries=20
-messaging.broker.url=failover:(tcp://{{ messaging_broker_url|default('localhost:61616') }})
+messaging.broker.url={{ messaging_broker_url|default('localhost:61616') }})
 
 # SPG settings
 spg.admin.dashlet.username.length=3


### PR DESCRIPTION
When pulled from the remote state it is already contained within the url