### PR TITLE
Changed rsyslog handling

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,8 @@
   service:
     name: chronyd
     state: restarted
+
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/tasks/configure_auditing.yml
+++ b/tasks/configure_auditing.yml
@@ -33,7 +33,6 @@
   with_items:
     - logstash
     - filebeat
-    - rsyslog
     - awslogs
   become: true
 
@@ -78,6 +77,8 @@
     src: "{{ role_path }}/templates/rsyslog/rsyslog.conf.j2"
     dest: "/etc/rsyslog.conf"
   become: true
+  notify:
+    - restart rsyslog
 
 - name: Replace our awslogs conf file
   template:
@@ -91,6 +92,5 @@
   with_items:
     - logstash
     - filebeat
-    - rsyslog
     - awslogs
   become: true


### PR DESCRIPTION
Removed rsyslog ansible role, needs updating as it was causing rolling update Alfresco ASG to fail. Restarting rsyslog hangs for 8 mins, causing asg health check to retrovision nodes

Closes #59 