### PR TITLE
Update alfresco-global.properties

### DIFF
--- a/templates/alfresco-global.properties
+++ b/templates/alfresco-global.properties
@@ -182,7 +182,6 @@ zaizi.noms.mpx.schema.913.date=2018-02-08
 
 # Remove the following properties from audit
 zaizi.audit.filter=siteName,groups,aspects
-zaizi.noms.invalidCharacters=\\/:*\"\"<>|
 # Should PREVIOUS_CONVICTIONS and CPS_PACK be locked on upload, or treated as an error?
 zaizi.upload.lockprecons=false
 # Do we allow the deprecated spelling of APPREFFERAL?


### PR DESCRIPTION
Removed special charectors restriction property. This is in the war file and does not need to be overridden in the external property