### PR TITLE
Bump action tag to fix versioning issue

### DIFF
--- a/.github/workflows/tag-master-branch-on-merge.yaml
+++ b/.github/workflows/tag-master-branch-on-merge.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@develop
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.33.0
+        uses: anothrNick/github-tag-action@1.36.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: ministryofjustice


### PR DESCRIPTION
Context:

> Hey folks, if you are using the GitHub action anothrNick/github-tag-action to do semantic versioning, be aware that today’s Git security fix broke it so all tags get set to 1.0.0 which can have “interesting” side effects. You need to be on at least version 1.36.0 of the action for the fix.